### PR TITLE
docs: change git url to https to allow anonymous access

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Currently, there are images for the following projects:
    1. `mkdir dimitriOS && cd dimitriOS`
 3. Choose the `dimitriOS` manifest that includes the BSP for your board and load
 the respective board configuration. E.g. For Raspberry Pi boards:
-   1. `repo init -u git@github.com:platisd/dimitriOS-manifest.git -m dimitriOS-rpi.xml`
+   1. `repo init -u https://github.com/platisd/dimitriOS-manifest.git -m dimitriOS-rpi.xml`
    2. `export TEMPLATECONF=~/dimitriOS/layers/meta-dimitriOS/rpi-conf/`
 4. Fetch the source code
    1. `repo sync`


### PR DESCRIPTION
The git protocol requires SSH access. Use HTTPS to `git clone` anonymously.

```
$ repo init -u git@github.com:platisd/dimitriOS-manifest.git -m dimitriOS-rpi.xml
Downloading manifest from git@github.com:platisd/dimitriOS-manifest.git
Traceback (most recent call last):
  File "/home/user/src/dimitriOS/.repo/repo/main.py", line 630, in <module>
    _Main(sys.argv[1:])
  File "/home/user/src/dimitriOS/.repo/repo/main.py", line 604, in _Main
    result = run()
  File "/home/user/src/dimitriOS/.repo/repo/main.py", line 597, in <lambda>
    run = lambda: repo._Run(name, gopts, argv) or 0
  File "/home/user/src/dimitriOS/.repo/repo/main.py", line 266, in _Run
    result = cmd.Execute(copts, cargs)
  File "/home/user/src/dimitriOS/.repo/repo/subcmds/init.py", line 531, in Execute
    self._SyncManifest(opt)
  File "/home/user/src/dimitriOS/.repo/repo/subcmds/init.py", line 232, in _SyncManifest
    default_branch = m.ResolveRemoteHead()
  File "/home/user/src/dimitriOS/.repo/repo/project.py", line 1926, in ResolveRemoteHead
    output = self.bare_git.ls_remote('-q', '--symref', '--exit-code', name, 'HEAD')
  File "/home/user/src/dimitriOS/.repo/repo/project.py", line 3041, in runner
    (self._project.name, name, p.stderr))
error.GitError: manifests ls-remote: git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```