### PR TITLE
meta-dimitriOS: switch git protocol to HTTPS to allow anonymous access

### DIFF
--- a/recipes-cryptopuck/cryptopuck/cryptopuck_git.bb
+++ b/recipes-cryptopuck/cryptopuck/cryptopuck_git.bb
@@ -15,7 +15,7 @@ RDEPENDS_${PN} = " \
 "
 
 SRC_URI = "\
-    git://git@github.com/platisd/cryptopuck;protocol=ssh;branch=master \
+    git://git@github.com/platisd/cryptopuck;protocol=https;branch=master \
     file://cryptopuck.service \
     file://key.public \
 "

--- a/recipes-workshop/employee-getter/employee-getter_git.bb
+++ b/recipes-workshop/employee-getter/employee-getter_git.bb
@@ -11,7 +11,7 @@ RDEPENDS_${PN} = "\
 "
 
 SRC_URI = "\
-    git://git@github.com/platisd/example-dimitriOS-cmake-project;protocol=ssh;branch=master \
+    git://git@github.com/platisd/example-dimitriOS-cmake-project;protocol=https;branch=master \
     file://employee-getter.service \
 "
 SRCREV = "${AUTOREV}"


### PR DESCRIPTION
The `ssh` protocol requires access rights to the repository. Use the `https` protocol instead since it allows anonymous access.

The resolves the following error when listing recipes.

```
$ bitbake -s
Loading cache: 100% |###############################################################################################################################################################################| Time: 0:00:00
Loaded 18 entries from dependency cache.
WARNING: /workdir/build/../layers/meta-dimitriOS/recipes-workshop/employee-getter/employee-getter_git.bb: Exception during build_dependencies for AUTOREV                                           | ETA:  0:00:22
WARNING: /workdir/build/../layers/meta-dimitriOS/recipes-workshop/employee-getter/employee-getter_git.bb: Error during finalise of /workdir/build/../layers/meta-dimitriOS/recipes-workshop/employee-getter/employee-getter_git.bb
ERROR: ExpansionError during parsing /workdir/build/../layers/meta-dimitriOS/recipes-workshop/employee-getter/employee-getter_git.bb
Traceback (most recent call last):
  File "/workdir/layers/poky/bitbake/lib/bb/fetch2/__init__.py", line 1177, in srcrev_internal_helper(ud=<bb.fetch2.FetchData object at 0x7fa0ad0374e0>, d=<bb.data_smart.DataSmart object at 0x7fa0ad255d30>, name='default'):
         if srcrev == "AUTOINC":
    >        srcrev = ud.method.latest_revision(ud, d, name)
     
  File "/workdir/layers/poky/bitbake/lib/bb/fetch2/__init__.py", line 1592, in Git.latest_revision(ud=<bb.fetch2.FetchData object at 0x7fa0ad0374e0>, d=<bb.data_smart.DataSmart object at 0x7fa0ad255d30>, name='default'):
             except KeyError:
    >            revs[key] = rev = self._latest_revision(ud, d, name)
                 return rev
  File "/workdir/layers/poky/bitbake/lib/bb/fetch2/git.py", line 631, in Git._latest_revision(ud=<bb.fetch2.FetchData object at 0x7fa0ad0374e0>, d=<bb.data_smart.DataSmart object at 0x7fa0ad255d30>, name='default'):
             """
    >        output = self._lsremote(ud, d, "")
             # Tags of the form ^{} may not work, need to fallback to other form
  File "/workdir/layers/poky/bitbake/lib/bb/fetch2/git.py", line 620, in Git._lsremote(ud=<bb.fetch2.FetchData object at 0x7fa0ad0374e0>, d=<bb.data_smart.DataSmart object at 0x7fa0ad255d30>, search=''):
                     bb.fetch2.check_network_access(d, cmd, repourl)
    >            output = runfetchcmd(cmd, d, True)
                 if not output:
  File "/workdir/layers/poky/bitbake/lib/bb/fetch2/__init__.py", line 894, in runfetchcmd(cmd='export PSEUDO_DISABLED=1; unset _PYTHON_SYSCONFIGDATA_NAME; export PATH="/workdir/layers/poky/scripts:/workdir/build/tmp/work/cortexa7t2hf-neon-vfpv4-poky-linux-gnueabi/employee-getter/git-r0/recipe-sysroot-native/usr/bin/arm-poky-linux-gnueabi:/workdir/build/tmp/work/cortexa7t2hf-neon-vfpv4-poky-linux-gnueabi/employee-getter/git-r0/recipe-sysroot/usr/bin/crossscripts:/workdir/build/tmp/work/cortexa7t2hf-neon-vfpv4-poky-linux-gnueabi/employee-getter/git-r0/recipe-sysroot-native/usr/sbin:/workdir/build/tmp/work/cortexa7t2hf-neon-vfpv4-poky-linux-gnueabi/employee-getter/git-r0/recipe-sysroot-native/usr/bin:/workdir/build/tmp/work/cortexa7t2hf-neon-vfpv4-poky-linux-gnueabi/employee-getter/git-r0/recipe-sysroot-native/sbin:/workdir/build/tmp/work/cortexa7t2hf-neon-vfpv4-poky-linux-gnueabi/employee-getter/git-r0/recipe-sysroot-native/bin:/workdir/layers/poky/bitbake/bin:/workdir/build/tmp/hosttools"; export HOME="/home/pokyuser"; git -c core.fsyncobjectfiles=0 ls-remote "ssh://git@github.com/platisd/example-dimitriOS-cmake-project" ', d=<bb.data_smart.DataSmart object at 0x7fa0ad255d30>, quiet=True, cleanup=[], log=None, workdir=None):
     
    >        raise FetchError(error_message)
     
bb.data_smart.ExpansionError: Failure expanding variable SRCPV, expression was ${@bb.fetch2.get_srcrev(d)} which triggered exception FetchError: Fetcher failure: Fetch command export PSEUDO_DISABLED=1; unset _PYTHON_SYSCONFIGDATA_NAME; export PATH="/workdir/layers/poky/scripts:/workdir/build/tmp/work/cortexa7t2hf-neon-vfpv4-poky-linux-gnueabi/employee-getter/git-r0/recipe-sysroot-native/usr/bin/arm-poky-linux-gnueabi:/workdir/build/tmp/work/cortexa7t2hf-neon-vfpv4-poky-linux-gnueabi/employee-getter/git-r0/recipe-sysroot/usr/bin/crossscripts:/workdir/build/tmp/work/cortexa7t2hf-neon-vfpv4-poky-linux-gnueabi/employee-getter/git-r0/recipe-sysroot-native/usr/sbin:/workdir/build/tmp/work/cortexa7t2hf-neon-vfpv4-poky-linux-gnueabi/employee-getter/git-r0/recipe-sysroot-native/usr/bin:/workdir/build/tmp/work/cortexa7t2hf-neon-vfpv4-poky-linux-gnueabi/employee-getter/git-r0/recipe-sysroot-native/sbin:/workdir/build/tmp/work/cortexa7t2hf-neon-vfpv4-poky-linux-gnueabi/employee-getter/git-r0/recipe-sysroot-native/bin:/workdir/layers/poky/bitbake/bin:/workdir/build/tmp/hosttools"; export HOME="/home/pokyuser"; git -c core.fsyncobjectfiles=0 ls-remote "ssh://git@github.com/platisd/example-dimitriOS-cmake-project"  failed with exit code 128, output:
Host key verification failed.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.



Summary: There were 2 WARNING messages shown.
Summary: There was 1 ERROR message shown, returning a non-zero exit code.
```